### PR TITLE
Lower apple-xctest smoke Package tools-version to 6.0

### DIFF
--- a/tools/apple_xctest_smoke.sh
+++ b/tools/apple_xctest_smoke.sh
@@ -50,7 +50,7 @@ EOF
 
 package_file="$work_root/Package.swift"
 cat >"$package_file" <<'EOF'
-// swift-tools-version: 6.3
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary
- `tools/apple_xctest_smoke.sh` generated a `Package.swift` pinned to `// swift-tools-version: 6.3`, but GitHub's `macos-15` runner ships Xcode 16.4 / Swift 6.1.0, so SwiftPM rejected the package and apple-baseline fast-failed in ~22s on every PR for the past two weeks.
- Lowered the floor to `6.0` — the minimum that still supports the existing `swiftLanguageModes: [.v6]` declaration. Any Swift 6.x toolchain (CI's 6.1, our reference Mac's 6.3) now accepts the package.
- Verified on a macOS 26.4 / Swift 6.3 host: `apple-xctest-smoke: passed`, exit 0.

## Test plan
- [x] Run patched script on iep-stack-o-macs-01 (macOS 26.4 / Xcode 26.4 / Swift 6.3) — passed.
- [ ] Watch the `apple-baseline` job on this PR for the first green build since 2026-04-28.
- [ ] Note for follow-up: track self-hosting iep-stack-o-macs-01 as a dedicated apple-baseline runner so this gate exercises the real target toolchain rather than a runner two majors behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)