### PR TITLE
Fix ARLEN_BUG_027 sanitizer test (ASan double-load crash)

### DIFF
--- a/tests/unit/BuildPolicyTests.m
+++ b/tests/unit/BuildPolicyTests.m
@@ -148,7 +148,7 @@
     XCTAssertTrue([[NSFileManager defaultManager] isExecutableFileAtPath:arlenPath],
                   @"expected test-unit prerequisite to build executable %@", arlenPath);
     NSString *command = [NSString stringWithFormat:
-        @"cd %@ && ARLEN_FRAMEWORK_ROOT=%@ timeout 20s %@/build/arlen build --json > %@",
+        @"cd %@ && LD_PRELOAD='' ARLEN_FRAMEWORK_ROOT=%@ timeout 20s %@/build/arlen build --json > %@",
         [self shellQuoted:repoRoot],
         [self shellQuoted:fixtureRoot],
         [self shellQuoted:repoRoot],


### PR DESCRIPTION
## Summary

Restores green sanitizer-gate by fixing a single-line env-propagation bug in the ARLEN_BUG_027 unit test. The test has been failing in `linux-sanitizers` on every push since 2026-05-04 (9+ days red on main).

## Root cause

When the sanitizer matrix runs, `xctest` is launched with `LD_PRELOAD=libasan.so:libubsan.so`. The ARLEN_BUG_027 test spawns `bash → timeout → arlen` via `NSTask`, which inherits the parent env. The `arlen` binary is itself link-time sanitized (`-fsanitize=address`), so its dynamic dependencies already include `libasan.so`. Adding the same library via `LD_PRELOAD` loads it twice and fatally errors:

```
==3945161==Your application is linked against incompatible ASan runtimes.
```

`arlen` exits before producing any JSON output, then the test's assertions on exit code and JSON content fire.

## Fix

One-line: prepend `LD_PRELOAD=''` to the shell command so the `timeout`/`arlen` invocation sees an empty `LD_PRELOAD`. `arlen` then uses its own link-time ASan runtime exclusively.

This matches the existing convention from `tests/unit/Phase13ETests.m:781` (`LD_PRELOAD='' make arlen`), which exists for the same reason.

## Test plan

- [x] CI: `linux-sanitizers` should pass for the first time since 2026-05-04
- [x] CI: every other gate should remain green
- [x] No production code changed — fix is test-setup only

🤖 Generated with [Claude Code](https://claude.com/claude-code)