### PR TITLE
Pass 3 F2 batch 2: rename run_phase5e_quality.sh to run_linux_quality_gate.sh

### DIFF
--- a/.github/workflows/linux-quality.yml
+++ b/.github/workflows/linux-quality.yml
@@ -26,12 +26,12 @@ jobs:
         run: |
           bash ./tools/ci/install_ci_dependencies.sh
 
-      - name: Run Phase 5E quality gate
+      - name: Run linux quality gate
         env:
           GNUSTEP_USER_ROOT: ${{ github.workspace }}/.gnustep
           ARLEN_PERF_BASELINE_ROOT: tests/performance/baselines/iep-apt
         run: |
-          bash ./tools/ci/run_phase5e_quality.sh
+          bash ./tools/ci/run_linux_quality_gate.sh
 
       - name: Upload perf + confidence artifacts
         if: github.event_name == 'workflow_dispatch' || failure()

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1148,7 +1148,7 @@ Lifecycle diagnostics:
 - `make phase20-confidence`: generate reflection/type-codec/backend-tier confidence artifacts in `build/release_confidence/phase20`
 - `tools/ci/run_phase30_confidence.sh`: run the Apple baseline confidence gate and generate artifacts in `build/release_confidence/phase30`
 - `tools/ci/run_phase20_focused.sh`: explicit focused lane runner for builder/schema/routing plus PostgreSQL/MSSQL live coverage
-- `tools/ci/run_phase5e_quality.sh`: explicit data-layer CI gate entrypoint
+- `tools/ci/run_linux_quality_gate.sh`: explicit data-layer CI gate entrypoint
 - `tools/ci/run_phase5e_sanitizers.sh`: explicit sanitizer CI gate entrypoint
  - remains the explicit sanitizer blocking lane for ASan/UBSan unit + runtime/data-layer checks plus sanitizer confidence artifact generation under `build/release_confidence/phase9h`
  - set `ARLEN_SANITIZER_INCLUDE_INTEGRATION=1` to include full integration suite (default is `0`)

--- a/tests/unit/BuildPolicyTests.m
+++ b/tests/unit/BuildPolicyTests.m
@@ -676,7 +676,7 @@
 
 - (void)testPhase5EQualityPipelineIncludesJSONPerformanceGate {
   NSString *repoRoot = [[NSFileManager defaultManager] currentDirectoryPath];
-  NSString *scriptPath = [repoRoot stringByAppendingPathComponent:@"tools/ci/run_phase5e_quality.sh"];
+  NSString *scriptPath = [repoRoot stringByAppendingPathComponent:@"tools/ci/run_linux_quality_gate.sh"];
   NSString *script = [self readFile:scriptPath];
 
   XCTAssertTrue([script containsString:@"check_runtime_json_abstraction.py"]);
@@ -1371,7 +1371,7 @@
       readFile:[repoRoot stringByAppendingPathComponent:@"tools/ci/run_phase9j_release_certification.sh"]];
 
   XCTAssertTrue([script containsString:@"make clean"]);
-  XCTAssertTrue([script containsString:@"bash ./tools/ci/run_phase5e_quality.sh"]);
+  XCTAssertTrue([script containsString:@"bash ./tools/ci/run_linux_quality_gate.sh"]);
   XCTAssertTrue([script containsString:@"stash_release_artifact_dir phase5e"]);
   XCTAssertTrue([script containsString:@"stash_release_artifact_dir phase9i"]);
   XCTAssertTrue([script containsString:@"restore_release_artifact_dir phase5e"]);

--- a/tools/ci/run_linux_quality_gate.sh
+++ b/tools/ci/run_linux_quality_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+export ARLEN_PHASE5E_SOAK_ITERS="${ARLEN_PHASE5E_SOAK_ITERS:-240}"
+
+python3 ./tools/ci/check_runtime_json_abstraction.py --repo-root "$repo_root"
+bash ./tools/ci/run_phase5a_quality.sh
+bash ./tools/ci/run_runtime_concurrency_gate.sh
+bash ./tools/ci/run_phase9i_fault_injection.sh
+bash ./tools/ci/run_phase10e_json_performance.sh
+bash ./tools/ci/run_phase10g_dispatch_performance.sh
+bash ./tools/ci/run_phase10h_http_parse_performance.sh
+bash ./tools/ci/run_phase10m_blob_throughput.sh
+python3 ./tools/ci/generate_phase5e_confidence_artifacts.py \
+  --repo-root "$repo_root" \
+  --output-dir "$repo_root/build/release_confidence/phase5e"
+
+echo "ci: phase5e quality gate complete"

--- a/tools/ci/run_phase5e_quality.sh
+++ b/tools/ci/run_phase5e_quality.sh
@@ -1,21 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$repo_root"
-
-export ARLEN_PHASE5E_SOAK_ITERS="${ARLEN_PHASE5E_SOAK_ITERS:-240}"
-
-python3 ./tools/ci/check_runtime_json_abstraction.py --repo-root "$repo_root"
-bash ./tools/ci/run_phase5a_quality.sh
-bash ./tools/ci/run_runtime_concurrency_gate.sh
-bash ./tools/ci/run_phase9i_fault_injection.sh
-bash ./tools/ci/run_phase10e_json_performance.sh
-bash ./tools/ci/run_phase10g_dispatch_performance.sh
-bash ./tools/ci/run_phase10h_http_parse_performance.sh
-bash ./tools/ci/run_phase10m_blob_throughput.sh
-python3 ./tools/ci/generate_phase5e_confidence_artifacts.py \
-  --repo-root "$repo_root" \
-  --output-dir "$repo_root/build/release_confidence/phase5e"
-
-echo "ci: phase5e quality gate complete"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_dir/lib/run_lane_compat.sh"
+aln_lane_compat_exec "run_linux_quality_gate.sh" "$@"

--- a/tools/ci/run_phase9j_release_certification.sh
+++ b/tools/ci/run_phase9j_release_certification.sh
@@ -40,7 +40,7 @@ if [[ "$phase9j_skip_gates" != "1" ]]; then
   # Release certification must rebuild from a clean tree so earlier sanitizer
   # lanes cannot leak instrumented binaries into the quality gate.
   make clean
-  bash ./tools/ci/run_phase5e_quality.sh
+  bash ./tools/ci/run_linux_quality_gate.sh
   # The sanitizer lane does its own clean rebuild, so preserve the earlier
   # quality/fault-injection evidence that Phase 9J still needs to certify.
   stash_release_artifact_dir phase5e


### PR DESCRIPTION
## Summary

Second rename batch using the wrapper-compat helper from PR #10. Renames the linux-quality entry script and updates its callers.

## Renames

- \`tools/ci/run_phase5e_quality.sh\` → \`tools/ci/run_linux_quality_gate.sh\`
- the old path becomes a 5-line deprecation wrapper using \`aln_lane_compat_exec\`

## Caller updates

- \`.github/workflows/linux-quality.yml\`: invokes new name; step label updated from "Phase 5E quality gate" to "linux quality gate"
- \`tools/ci/run_phase9j_release_certification.sh\`: invokes new name (release-cert is a downstream lane that runs the linux quality gate before its own work)
- \`docs/CLI_REFERENCE.md\`: entrypoint listing uses new name
- \`tests/unit/BuildPolicyTests.m\`: two assertions updated to inspect the new path. \`testPhase5EQualityPipelineIncludesJSONPerformanceGate\` now reads \`run_linux_quality_gate.sh\`; the release-certification test now asserts the new bash invocation string

## Deferred follow-ups (same shape as PR #10)

- \`generate_phase5e_confidence_artifacts.py\` filename + artifact filenames stay phase5e-named to avoid breaking downstream consumers
- \`ARLEN_PHASE5E_SOAK_ITERS\` env var keeps its name
- \`build/release_confidence/phase5e/\` output dir stays
- ~7 sub-scripts invoked by the gate (\`run_phase10e_json_performance.sh\` etc) keep their phase names

Future rename batches: sanitizer-matrix family, release-certification family, then deeper internal renames once consumers are audited.

## Test plan

- [x] CI: \`linux-quality\` should pass under the renamed invocation
- [x] CI: \`testPhase5EQualityPipelineIncludesJSONPerformanceGate\` should pass against the new path
- [x] No remaining \`run_phase5e_quality\` references outside the compat wrapper itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)