### PR TITLE
Fix ALNPg pool recirculating dead PostgreSQL connections (2026-05-18 outage)

### DIFF
--- a/src/Arlen/Data/ALNPg.m
+++ b/src/Arlen/Data/ALNPg.m
@@ -1768,6 +1768,7 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
 
 - (BOOL)hasActiveTransaction;
 - (BOOL)checkConnectionLiveness:(NSError **)error;
+- (BOOL)isConnectionUsable;
 - (BOOL)deallocatePreparedStatementNamed:(NSString *)name error:(NSError **)error;
 
 @end
@@ -1860,6 +1861,26 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
 
 - (BOOL)hasActiveTransaction {
   return _inTransaction;
+}
+
+// Authoritative health of the underlying socket. Unlike `isOpen` (a cached
+// flag flipped only by an explicit -close), this asks libpq directly and is
+// free of a round-trip: libpq marks a connection CONNECTION_BAD as soon as a
+// send/recv on it fails, so a connection killed while pooled (server restart,
+// idle timeout, network drop) reports NO here even though `isOpen` is still
+// YES. A connection that merely returned a SQL error keeps CONNECTION_OK and
+// stays usable.
+- (BOOL)isConnectionUsable {
+  return _conn != NULL && self.isOpen && ALNPQstatus(_conn) == ALNConnectionOK;
+}
+
+// Close the connection if libpq has marked the socket dead. Called on the
+// query-failure path so a poisoned connection is torn down immediately
+// instead of being handed back to the pool.
+- (void)closeIfConnectionLost {
+  if (_conn != NULL && ALNPQstatus(_conn) != ALNConnectionOK) {
+    [self close];
+  }
 }
 
 - (BOOL)checkConnectionLiveness:(NSError **)error {
@@ -2257,6 +2278,7 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
                               detail,
                               sql);
     }
+    [self closeIfConnectionLost];
     return NULL;
   }
 
@@ -2291,6 +2313,7 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
                               detail,
                               sql);
     }
+    [self closeIfConnectionLost];
     return NULL;
   }
 
@@ -3185,7 +3208,14 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
   _preparedStatementReusePolicy = ALNPgPreparedStatementReusePolicyAuto;
   _preparedStatementCacheLimit = 128;
   _builderCompilationCacheLimit = 128;
-  _connectionLivenessChecksEnabled = NO;
+  // Default ON: validate a pooled connection before handing it out. The
+  // release-time status gate and failure-path teardown evict connections
+  // that die while checked out, but a connection can also die while sitting
+  // idle in the pool (server restart, idle/firewall timeout during a quiet
+  // period). The on-borrow SELECT 1 is the only thing that catches that case
+  // before a request fails. Previously NO, which let a single weekend
+  // network blip silently poison the whole pool until a manual restart.
+  _connectionLivenessChecksEnabled = YES;
   _includeSQLInDiagnosticsEvents = NO;
   _emitDiagnosticsEventsToStderr = NO;
   _queryDiagnosticsListener = nil;
@@ -3207,6 +3237,15 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
     while ([self.idleConnections count] > 0) {
       ALNPgConnection *connection = [self.idleConnections lastObject];
       [self.idleConnections removeLastObject];
+      // Drop a locally-known-dead idle connection with zero round-trip
+      // before doing any further work. This self-heals the pool: dead
+      // connections are discarded here and the create-new path below
+      // refills capacity, so the pool recovers its size instead of
+      // handing out poison. Works even when liveness checks are disabled.
+      if (![connection isConnectionUsable]) {
+        [connection close];
+        continue;
+      }
       connection.preparedStatementReusePolicy = self.preparedStatementReusePolicy;
       connection.preparedStatementCacheLimit = self.preparedStatementCacheLimit;
       connection.builderCompilationCacheLimit = self.builderCompilationCacheLimit;
@@ -3269,7 +3308,13 @@ static NSDictionary *ALNPgRowDictionary(PGresult *result,
         [connection close];
       }
     }
-    if (connection.isOpen) {
+    // Gate re-pooling on the real libpq socket status, not the cached
+    // `isOpen` flag. A connection whose socket died while checked out (server
+    // restart, idle/firewall drop) still reports isOpen == YES; returning it
+    // here poisons the pool and every subsequent borrower fails the same way
+    // until the worker is restarted. isConnectionUsable asks libpq directly,
+    // so a dead connection is torn down instead of recirculated.
+    if ([connection isConnectionUsable]) {
       [self.idleConnections addObject:connection];
     } else {
       [connection close];

--- a/tests/unit/PgTests.m
+++ b/tests/unit/PgTests.m
@@ -15,6 +15,54 @@
 #import "ALNSchemaCodegen.h"
 #import "ALNSQLBuilder.h"
 
+// `isConnectionUsable` / `checkConnectionLiveness:` / `hasActiveTransaction`
+// live in ALNPg's private class continuation. Re-declare the selectors here so
+// the regression fake can override them and the assertions can call them.
+@interface ALNPgConnection (ALNPgPoolRegressionHooks)
+- (BOOL)isConnectionUsable;
+- (BOOL)checkConnectionLiveness:(NSError **)error;
+- (BOOL)hasActiveTransaction;
+@end
+
+// A connection stand-in that never touches libpq, so the pool-poisoning
+// regression runs in the Linux quality gate without a live PostgreSQL.
+// `simulatedOpen` models the stale cached `isOpen` flag; `simulatedUsable`
+// models what libpq's PQstatus would actually report.
+@interface ALNFakePgConnection : ALNPgConnection
+@property(nonatomic, assign) BOOL simulatedOpen;
+@property(nonatomic, assign) BOOL simulatedUsable;
+@property(nonatomic, assign) NSInteger closeCount;
+@end
+
+@implementation ALNFakePgConnection
+
+- (BOOL)isOpen {
+  return self.simulatedOpen;
+}
+
+- (BOOL)isConnectionUsable {
+  return self.simulatedUsable;
+}
+
+- (BOOL)checkConnectionLiveness:(NSError **)error {
+  if (error != NULL) {
+    *error = nil;
+  }
+  return self.simulatedUsable;
+}
+
+- (BOOL)hasActiveTransaction {
+  return NO;
+}
+
+- (void)close {
+  self.closeCount += 1;
+  self.simulatedOpen = NO;
+  self.simulatedUsable = NO;
+}
+
+@end
+
 @interface PgTests : XCTestCase
 @end
 
@@ -30,6 +78,77 @@
       NSStringFromClass([self class]),
       NSStringFromSelector(selector),
       @"set ARLEN_PG_TEST_DSN to run live PostgreSQL data-layer coverage");
+}
+
+#pragma mark - Connection-pool poisoning regression (no live DB required)
+
+// Regression for the 2026-05-18 outage: a connection whose socket died while
+// checked out still reported isOpen == YES, so releaseConnection: returned it
+// to the idle pool and every subsequent borrower failed identically until a
+// manual restart. The release gate must use the real libpq status, not the
+// cached flag — even with on-borrow liveness checks disabled.
+- (void)testReleaseConnectionDiscardsDeadButOpenConnection {
+  NSError *error = nil;
+  ALNPg *pool = [[ALNPg alloc]
+      initWithConnectionString:@"postgresql://127.0.0.1:1/arlen_pool_regression"
+                maxConnections:2
+                         error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(pool);
+  pool.connectionLivenessChecksEnabled = NO;  // isolate the release-time gate
+
+  ALNFakePgConnection *dead = [ALNFakePgConnection new];
+  dead.simulatedOpen = YES;    // stale flag still claims the socket is open
+  dead.simulatedUsable = NO;   // libpq would report CONNECTION_BAD
+
+  [pool releaseConnection:dead];
+  XCTAssertEqual((NSInteger)1, dead.closeCount,
+                 @"a dead-but-open connection must be torn down on release");
+
+  NSError *acquireError = nil;
+  ALNPgConnection *next = [pool acquireConnection:&acquireError];
+  XCTAssertNotEqual(next, (ALNPgConnection *)dead,
+                    @"the dead connection must not be recirculated");
+}
+
+// Guards against over-eviction: the fix must not nuke the pool. A connection
+// libpq still reports OK must stay pooled and be reused.
+- (void)testReleaseConnectionKeepsAndReusesUsableConnection {
+  NSError *error = nil;
+  ALNPg *pool = [[ALNPg alloc]
+      initWithConnectionString:@"postgresql://127.0.0.1:1/arlen_pool_regression"
+                maxConnections:2
+                         error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(pool);
+
+  ALNFakePgConnection *good = [ALNFakePgConnection new];
+  good.simulatedOpen = YES;
+  good.simulatedUsable = YES;  // libpq reports CONNECTION_OK
+
+  [pool releaseConnection:good];
+  XCTAssertEqual((NSInteger)0, good.closeCount,
+                 @"a usable connection must stay pooled");
+
+  NSError *acquireError = nil;
+  ALNPgConnection *reused = [pool acquireConnection:&acquireError];
+  XCTAssertNil(acquireError);
+  XCTAssertEqual(reused, (ALNPgConnection *)good,
+                 @"a usable connection must be reused, not discarded");
+}
+
+// On-borrow liveness checks are the only thing that catches a connection that
+// died while idle in the pool; after the outage the safe default is ON.
+- (void)testConnectionLivenessChecksDefaultEnabled {
+  NSError *error = nil;
+  ALNPg *pool = [[ALNPg alloc]
+      initWithConnectionString:@"postgresql://127.0.0.1:1/arlen_pool_regression"
+                maxConnections:1
+                         error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(pool);
+  XCTAssertTrue(pool.connectionLivenessChecksEnabled,
+                @"liveness checks must default ON after the pool-poisoning fix");
 }
 
 - (NSInteger)phase5ESoakIterationCount {


### PR DESCRIPTION
## Summary

Postmortem fix for the **2026-05-18 outage** (DB-backed routes 4xx/5xx for ~13h while `/healthz` etc. stayed green).

**Root cause:** a pooled PostgreSQL connection whose socket died while checked out (server restart, idle/firewall timeout, weekend network blip) still reported `isOpen == YES` — a cached flag only cleared by an explicit `-close`. `releaseConnection:` gated re-pooling on that stale flag, so the dead connection went back into the idle pool and every subsequent borrower failed identically until a manual worker restart. `connectionLivenessChecksEnabled` (the on-borrow `SELECT 1` that would have caught it) defaulted to `NO`.

## Changes

- **`-[ALNPgConnection isConnectionUsable]`** — authoritative, round-trip-free libpq `PQstatus` check. Unlike `isOpen`, a connection libpq has marked `CONNECTION_BAD` reports `NO`; a connection that merely returned a SQL error stays usable (no over-eviction).
- **`releaseConnection:` / `acquireConnection:`** gate on `isConnectionUsable` instead of the cached flag, so dead connections are torn down rather than recirculated and the pool self-heals to size via the existing create-new path.
- **Query-failure path** (`closeIfConnectionLost`) tears down a libpq-marked-bad connection immediately so it can't be returned to the pool.
- **`connectionLivenessChecksEnabled` now defaults to `YES`** — the only layer that catches a connection that died while sitting *idle* in the pool, before a request fails.

## Tests

Three no-DB regression tests in `PgTests` (run in the Linux quality gate without a live PostgreSQL): dead-but-open connection is evicted on release even with liveness checks off; a usable connection is **not** over-evicted and is reused; the liveness default is `YES`. All pass; framework builds clean.

## Notes

- Same patch is also applied to the affected site's deploy branch for hotfix; this PR lands it in `main` for the FOSS release.
- Recommended pre-merge gate: `scripts/run_linux_quality_gate.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)