### PR TITLE
Add community files for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a defect in Arlen
+title: ""
+labels: bug
+assignees: ""
+---
+
+<!--
+For security vulnerabilities, do NOT open a public issue.
+See SECURITY.md for private reporting.
+-->
+
+## What happened
+
+<!-- A clear description of the defect and its impact. -->
+
+## Reproduction
+
+<!-- The smallest reproduction you can produce. A failing test or a short
+     app under examples/ style is ideal. -->
+
+```text
+Steps:
+1.
+2.
+3.
+```
+
+## Expected vs. actual
+
+- **Expected**:
+- **Actual**:
+
+## Environment
+
+- Arlen commit: `git rev-parse HEAD` →
+- Platform: <!-- e.g., Linux (Debian 13, clang 17, GNUstep 2.x) / macOS 15 (Apple toolchain) / Windows CLANG64 preview -->
+- GNUstep makefiles: `gnustep-config --variable=GNUSTEP_MAKEFILES` →
+- Relevant module / subsystem: <!-- e.g., ALNPg, EOC, auth, propane, codegen -->
+
+## Logs and diagnostics
+
+<!-- Output of `./bin/arlen doctor`, any relevant log lines, stack traces,
+     or sanitizer output. Trim to what is relevant. -->
+
+```text
+```
+
+## Additional context
+
+<!-- Anything else: workarounds you tried, hypothesis on root cause,
+     related issues. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/danjboyd/Arlen/security/advisories/new
+    about: Report a security issue privately. Do not open a public issue.
+  - name: Documentation
+    url: https://github.com/danjboyd/Arlen/tree/main/docs
+    about: Browse Arlen's user-facing documentation before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+<!-- What are you trying to do? What is making it hard today? Concrete
+     scenarios are more useful than abstract requirements. -->
+
+## Proposed solution
+
+<!-- What you would like Arlen to do. If you have a sketch of the API
+     or developer experience, share it. -->
+
+```objc
+// Optional: a code or CLI sketch of how it would feel to use.
+```
+
+## Alternatives considered
+
+<!-- Other approaches you weighed, and why this one looks best. -->
+
+## Scope and compatibility
+
+- Is this a new module, an extension to an existing module, or a tooling change?
+- Would it require breaking changes to public API?
+- Does it touch the runtime (request handling, propane, realtime) or the
+  data layer? If so, what are the concurrency and durability implications?
+
+## Additional context
+
+<!-- Prior art in other frameworks (Rails, Django, Mojolicious, Laravel,
+     FastAPI, etc.) is welcome — it helps reviewers calibrate. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to Arlen are recorded in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once it cuts a 1.0 release. Prior to 1.0, breaking changes may land on `main`
+between any two commits; see [`docs/STATUS.md`](docs/STATUS.md) for the
+current capability snapshot.
+
+## [Unreleased]
+
+### Fixed
+
+- `ALNPg` connection pool no longer recirculates connections whose underlying
+  socket has died. The pool now consults `PQstatus` (via a new
+  `-isConnectionUsable` check) on both acquire and release, tears down
+  libpq-marked-bad connections on the query-failure path, and creates a fresh
+  connection in their place. The `connectionLivenessChecksEnabled` default is
+  now `YES`. Regression tests cover the pool-eviction paths without requiring
+  a live PostgreSQL instance.
+
+### Changed
+
+- Renamed `tools/ci/run_phase5e_quality.sh` to
+  `tools/ci/run_linux_quality_gate.sh` to reflect its capability rather than
+  its origin phase. A compatibility shim is retained for one release.
+- Renamed `tools/ci/run_phase30_confidence.sh` to
+  `tools/ci/run_apple_baseline_confidence.sh` with a matching compatibility
+  shim.
+
+## Releases
+
+No tagged releases have been published yet. Pre-1.0 work happens on `main`;
+deployment artifacts are produced from individual commits as needed.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+The Arlen project adopts the [Contributor Covenant, version 2.1][cc-2-1] as
+its Code of Conduct. The canonical text — including the pledge, expected
+standards, scope, enforcement guidelines, and attribution — lives at that
+URL and is incorporated here by reference.
+
+The summary, in plain terms: contribute in good faith, treat other
+participants with respect, and assume the same of others. Disagreement about
+technical direction is welcome; personal attacks and the patterns described
+in the Covenant are not.
+
+## Scope
+
+This Code of Conduct applies in all Arlen project spaces — the GitHub
+repository, issue and pull-request discussions, any official chat or forum
+the project later establishes — and when an individual is representing
+Arlen in public.
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct,
+report it privately to the project maintainers. Use either of the channels
+listed in [`SECURITY.md`](SECURITY.md) for private contact — GitHub's
+private vulnerability reporting works for conduct reports as well as
+security reports, and the message will reach the same maintainers.
+
+Reports will be handled confidentially. Maintainers will acknowledge receipt
+within a reasonable timeframe and, after review, take whatever action they
+judge proportionate — ranging from a private conversation to removal from
+project spaces.
+
+## Enforcement guidelines
+
+The project follows the four-tier enforcement ladder defined in section 4 of
+the Contributor Covenant: correction, warning, temporary ban, permanent ban.
+The specific text of each tier is defined in the canonical document.
+
+[cc-2-1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Arlen
+
+Thanks for your interest in Arlen. Arlen is a young framework with a small core
+team, and outside contributions are welcome — bug reports, reproductions,
+documentation fixes, and focused patches are all valuable.
+
+This file covers the practical mechanics: how to set up, what to run before
+opening a pull request, and the conventions reviewers will check for.
+
+## Before you start
+
+- File or comment on an issue first if the change is non-trivial. This lets us
+  surface design considerations before you invest implementation time.
+- For security-sensitive issues, do **not** open a public issue. Follow
+  [`SECURITY.md`](SECURITY.md) instead.
+- By contributing, you agree your contribution is licensed under the project's
+  [LICENSE](LICENSE) and you abide by the
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development environment
+
+Arlen targets GNUstep on Linux as the primary platform, with verified macOS
+(Apple runtime) and Windows `CLANG64` preview paths. The
+[Quick Start](README.md#quick-start) in the README is the canonical setup path.
+At a minimum you will need:
+
+- a clang-built GNUstep toolchain on Linux, or the Apple toolchain on macOS
+- initialized submodules: `git submodule update --init --recursive`
+- `tools-xctest` available if you plan to run the full unit suite
+
+Start every session with:
+
+```bash
+source tools/source_gnustep_env.sh   # Linux/GNUstep
+./bin/arlen doctor
+```
+
+If `arlen doctor` reports problems, fix them before building or running tests —
+nothing downstream will work reliably until the toolchain is healthy.
+
+## Building and running tests
+
+Common targets used in CI and by reviewers:
+
+| Target                   | What it does                                          |
+| ------------------------ | ----------------------------------------------------- |
+| `make all`               | Build the framework, tools, and bundled binaries.     |
+| `make test-unit`         | Run the XCTest-based unit suite.                      |
+| `make test-integration`  | Run integration tests (some require fixtures/DBs).    |
+| `make test-data-layer`   | Run PostgreSQL-backed data-layer tests.               |
+| `make ci-quality`        | The quality gate run in Linux CI.                     |
+| `make ci-sanitizers`     | ASan/UBSan sanitizer lanes.                           |
+| `make ci-docs`           | Documentation navigation and consistency checks.      |
+
+For a fast smoke check:
+
+```bash
+./bin/test --smoke-only
+```
+
+For a single test method (XCTest filter syntax):
+
+```bash
+make test-unit-filter TEST=PgTests/testReleaseConnectionDiscardsDeadButOpenConnection
+```
+
+## Pull request conventions
+
+- **Branches**: short, descriptive, kebab-case. Prefixes used in this repo:
+  `fix/`, `refactor/`, `docs/`, `feat/`. Example: `fix/eoc-partial-cache-key`.
+- **Commits**: one logical change per commit. Imperative subject line under
+  72 characters; body wrapped at 72 explaining the *why*, not the *what*.
+- **Pull requests**: use the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
+  Complete the validation checklist honestly — uncheck what you did not run
+  and say so in the description.
+- **Scope**: keep PRs focused. Refactors, formatting sweeps, and unrelated
+  fixes belong in their own PRs.
+- **CI**: all required checks must pass. If a check is flaky, say so in the
+  PR description rather than re-running silently.
+
+## Code style
+
+Arlen is Objective-C with GNUstep idioms. A few conventions reviewers will
+look for:
+
+- Public symbols use the `ALN` prefix; tests and tooling use `ALN`-test
+  scaffolding or no prefix when local.
+- Header comments document the *intended* contract; implementation comments
+  are reserved for non-obvious *why*. Don't restate what the code says.
+- Match the surrounding style of the file you are editing. If you think a
+  file's style is wrong, fix it in a separate refactor PR.
+- New public API should ship with a unit test and, where it spans subsystems,
+  an integration test.
+
+## Documentation
+
+User-facing documentation lives in [`docs/`](docs/). Engineering-internal
+material (phase roadmaps, dated reconciliations, milestone notes) lives in
+[`docs/internal/`](docs/internal/). Keep user-facing prose evergreen — no
+phase numbers, no dated milestones in titles or section headings.
+
+If you add a new user-facing document, list it under the appropriate section
+of [`docs/README.md`](docs/README.md) and run `make ci-docs` before opening
+the PR.
+
+## Reporting bugs
+
+Open a bug report from the GitHub Issues tab. Useful reports include:
+
+- Arlen commit (`git rev-parse HEAD`) and platform.
+- GNUstep toolchain version (`gnustep-config --variable=GNUSTEP_MAKEFILES`).
+- The smallest reproduction you can produce — ideally a failing test or a
+  ten-line app under `examples/`.
+- What you expected vs. what happened, including relevant log output.
+
+## Getting help
+
+- For setup or toolchain trouble, start with `./bin/arlen doctor` and the
+  guides under [`docs/`](docs/).
+- For design questions, open an issue tagged `discussion`.
+
+Thanks for helping make Arlen better.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+Arlen is a young framework and treats security reports seriously. This policy
+covers how to report a vulnerability, what to expect from us, and which
+versions receive fixes.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Use one of the following private channels:
+
+1. **GitHub private vulnerability reporting** (preferred). On the Arlen
+   repository, go to the **Security** tab and click **Report a
+   vulnerability**. This opens a private advisory visible only to maintainers.
+2. **Direct contact to the maintainer** via GitHub. If GitHub's private
+   reporting is unavailable, contact the repository owner privately via
+   GitHub and we will move the conversation to a private channel.
+
+When reporting, please include:
+
+- A description of the issue and the impact you believe it has.
+- The Arlen commit (`git rev-parse HEAD`) or version where you observed it.
+- The smallest reproduction you can share — a failing test, curl invocation,
+  or short app snippet under `examples/` style is ideal.
+- Whether the issue has been disclosed elsewhere.
+
+We will acknowledge receipt within **5 business days** and aim to provide an
+initial assessment (severity, affected components, expected fix window) within
+**10 business days**. We will keep you updated as we work on the fix and
+coordinate disclosure timing with you.
+
+## Scope
+
+In scope:
+
+- The Arlen framework runtime, including request handling, EOC templating,
+  the data layer (`ALNPg`, ORM surfaces, migrations), auth/admin/jobs/
+  notifications/storage/ops/search modules, realtime/event-stream support,
+  and the `propane` production runtime.
+- First-party tooling shipped in `bin/` and `tools/` (e.g., `arlen`,
+  `boomhauer`, `propane`, codegen).
+- Default configurations and templates produced by `arlen new`.
+
+Out of scope:
+
+- Third-party libraries, the GNUstep toolchain itself, or the operating
+  system. Report those upstream.
+- Vulnerabilities in example apps under `examples/` unless they reflect a
+  defect in Arlen itself.
+- Issues that require an attacker to already control the host running Arlen
+  (e.g., trivial misconfigurations once root is achieved).
+- EOC templates executing host-trusted Objective-C: by design, EOC templates
+  are trusted code. Untrusted template execution is not a supported use case.
+
+## Supported versions
+
+Arlen has not yet cut a 1.0 release. While in this pre-release phase, security
+fixes are made on the `main` branch and will be included in the next published
+release artifact. If you need a fix backported to a specific deployment, note
+the commit you are running in your report.
+
+## Coordinated disclosure
+
+We follow coordinated disclosure. After we and the reporter agree the fix is
+ready, we publish a security advisory with credit to the reporter (unless they
+prefer to remain anonymous) and ship the fix in a tagged release.
+
+## Hall of fame
+
+We will list security reporters here once we have published our first
+advisory.


### PR DESCRIPTION
## Summary

Drops the standard set of community files that GitHub's community-profile checklist looks for and that first-time visitors expect on a public framework repository. Purely additive — no existing files are touched.

- `CONTRIBUTING.md` — dev environment setup, real make targets (`ci-quality`, `ci-sanitizers`, `test-unit`, `ci-docs`), PR conventions, code style notes, doc internal/user-facing split rules.
- `SECURITY.md` — private vulnerability reporting via GitHub's Security tab, scope (in/out), supported-version stance for pre-1.0, coordinated disclosure language.
- `CODE_OF_CONDUCT.md` — adopts Contributor Covenant 2.1 by reference and points reports to the same private channels as `SECURITY.md`.
- `CHANGELOG.md` — Keep-a-Changelog format with an Unreleased section capturing the ALNPg pool fix and the `run_phase5e`/`run_phase30` → `linux_quality_gate`/`apple_baseline_confidence` renames.
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}` — structured templates that prompt for Arlen commit, GNUstep makefile path, and module/runtime impact; `config.yml` disables blank issues and surfaces the security advisory page and `docs/`.

## Post-merge follow-up

To activate the private reporting path that `SECURITY.md` documents, enable **Settings → Code security and analysis → Private vulnerability reporting** on the repository. One-click, requires repo admin.

## Validation

- [ ] None of the existing required CI checks apply to these doc-only/template files. `make ci-docs` checks `docs/` navigation; these files live at the repo root.
- [ ] Visual review of each file.

## CI Contract

- [ ] No CI workflow files were touched.

## Concurrency Impact

- [ ] No runtime, request, or shared-state code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)