### PR TITLE
Polish README for first-impression presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Arlen
 
+[![License: LGPL-2.0-or-later](https://img.shields.io/badge/license-LGPL--2.0--or--later-blue.svg)](LICENSE)
+[![Linux Quality](https://github.com/danjboyd/Arlen/actions/workflows/linux-quality.yml/badge.svg?branch=main)](https://github.com/danjboyd/Arlen/actions/workflows/linux-quality.yml)
+
 Arlen is a GNUstep-native Objective-C web framework with an MVC runtime, EOC templates (`.html.eoc`), and a developer server (`boomhauer`).
 
 Arlen is designed to solve the same class of problems as frameworks like
@@ -12,18 +15,53 @@ managed production runtime (`propane`). Linux with a clang-built GNUstep
 toolchain is the primary production target. macOS has a verified Apple-runtime
 path, and Windows `CLANG64` is currently a preview target.
 
+## Hello, Arlen
+
+What an Arlen app looks like — a controller and the EOC template it renders:
+
+```objc
+@interface HomeController : ALNController
+@end
+
+@implementation HomeController
+- (id)index:(ALNContext *)ctx {
+  NSDictionary *viewContext = @{
+    @"pageTitle": @"Hello, Arlen",
+    @"items": @[@"controller dispatch", @"EOC templates", @"implicit JSON"]
+  };
+  [self renderTemplate:@"home/index" context:viewContext error:NULL];
+  return nil;
+}
+@end
+```
+
+```html
+<%@ layout "layouts/main" %>
+<h1><%= $pageTitle %></h1>
+<ul>
+  <%@ render "partials/_item" collection:$items as:"item" %>
+</ul>
+```
+
+That route is wired up for you by `arlen new MyApp`; the
+[First App Guide](docs/FIRST_APP_GUIDE.md) takes you from there.
+
 ## Start Here
 
-If you are new to Arlen, start with:
+**New to Arlen** — pick the path that matches your platform:
 
-- `docs/GETTING_STARTED_MACOS.md` if you are targeting macOS with Apple APIs
-- `docs/FIRST_APP_GUIDE.md`
-- `docs/GETTING_STARTED.md`
-- `docs/GETTING_STARTED_TRACKS.md`
-- `docs/EOC_GUIDE.md` if you are building server-rendered pages with EOC
-- `docs/APP_AUTHORING_GUIDE.md`
-- `docs/LITE_MODE_GUIDE.md`
-- `docs/README.md`
+- [First App Guide](docs/FIRST_APP_GUIDE.md) — the shortest full-app walkthrough.
+- [Getting Started](docs/GETTING_STARTED.md) — Linux/GNUstep evaluation path; the primary production target.
+- [Getting Started on macOS](docs/GETTING_STARTED_MACOS.md) — Apple-runtime path.
+- [Getting Started Tracks](docs/GETTING_STARTED_TRACKS.md) — pick a track by role or use case.
+
+**Building apps:**
+
+- [App Authoring Guide](docs/APP_AUTHORING_GUIDE.md) — the long-form walkthrough.
+- [EOC Guide](docs/EOC_GUIDE.md) — server-rendered pages with EOC templates.
+- [Lite Mode Guide](docs/LITE_MODE_GUIDE.md) — single-file apps without scaffolding.
+
+**Full documentation:** the [Docs Index](docs/README.md) groups everything by intent (Building Apps, Modules, Data Layer, Operations and Deployment, Reference, Migration Guides, Examples).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Three focused changes to the README intro. All additive or re-organizational — no positioning prose (\"Why Arlen\", \"Good Fit If\", \"Probably Not\", \"What Ships Today\", \"Status\") is rewritten.

1. **License and CI status badges** below the title. Surfaces LGPL-2.0-or-later licensing and the Linux quality gate as the primary CI signal.
2. **\"Hello, Arlen\" code block** showing what an Arlen controller and its EOC template look like, drawn from real syntax used in the \`tech_demo\` example. A first-time visitor now sees framework code above the fold, before any toolchain setup instructions.
3. **Restructured \"Start Here\"** with explicit hierarchy and Linux-first ordering. Previously a flat eight-link list that led with the macOS guide despite Linux being the primary production target. Now grouped as \"New to Arlen\" (with platform-tagged entry points), \"Building apps\", and a pointer to the curated docs index.

## Validation

- [ ] Visual review of the rendered README on the PR's \"Files changed\" tab.
- [ ] \`make ci-docs\` — no narrative phase IDs were introduced; the user-facing-docs gate should remain green.

## CI Contract

- [ ] No CI workflow files were touched.

## Concurrency Impact

- [ ] No runtime, request, or shared-state code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)