### PR TITLE
Point ci-quality at run_linux_quality_gate.sh directly

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -924,7 +924,7 @@ phase20-confidence:
 >bash ./tools/ci/run_phase20_confidence.sh
 
 ci-quality:
->bash ./tools/ci/run_phase5e_quality.sh
+>bash ./tools/ci/run_linux_quality_gate.sh
 
 ci-sanitizers:
 >bash ./tools/ci/run_phase10m_sanitizer_matrix.sh


### PR DESCRIPTION
Leftover caller from the linux-quality rename: `make ci-quality` was still routing through the deprecated `run_phase5e_quality.sh` wrapper, printing a spurious deprecation notice on every quality-gate run. This invokes the renamed script directly.

## Verification

`make test-unit-filter TEST=BuildPolicyTests` → 47/47 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)